### PR TITLE
Add support for Laravel Scout 9 and Laravel 9

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -29,6 +29,11 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
 
+      - name: Start MySQL
+        run: |
+          sudo systemctl start mysql.service
+          mysql -uroot -proot -e 'CREATE DATABASE sqlout'
+
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
@@ -44,6 +49,11 @@ jobs:
       - name: Setup .env
         run: |
           touch .env
+          echo "DB_HOST=127.0.0.1"  >> .env
+          echo "DB_PORT=3306"       >> .env
+          echo "DB_DATABASE=sqlout" >> .env
+          echo "DB_USERNAME=root"   >> .env
+          echo "DB_PASSWORD=root"   >> .env
 
       - name: Execute tests
         run: vendor/bin/phpunit

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -16,7 +16,7 @@ jobs:
           - laravel: 9.*
             testbench: 7.*
           - laravel: 8.*
-            testbench: 6.*
+            testbench: 6.23
         exclude:
             - laravel: 9.*
               php: 7.4

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -41,5 +41,9 @@ jobs:
           composer require "illuminate/database:${{ matrix.laravel }}" "illuminate/support:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update
           composer update --${{ matrix.dependency-version }} --prefer-dist --no-interaction
 
+      - name: Setup .env
+        run: |
+          touch .env
+
       - name: Execute tests
         run: vendor/bin/phpunit

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,0 +1,45 @@
+name: "Run Tests"
+
+on: [push, pull_request]
+
+jobs:
+  test:
+
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        php: [8.1, 8.0, 7.4, 7.3]
+        laravel: [9.*, 8.*]
+        dependency-version: [prefer-lowest, prefer-stable]
+        include:
+          - laravel: 9.*
+            testbench: 7.*
+          - laravel: 8.*
+            testbench: 6.*
+        exclude:
+            - laravel: 9.*
+              php: 7.4
+            - laravel: 9.*
+              php: 7.3
+
+    name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          extensions: curl, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, iconv
+          coverage: none
+
+      - name: Install dependencies
+        run: |
+          composer require "illuminate/database:${{ matrix.laravel }}" "illuminate/support:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update
+          composer update --${{ matrix.dependency-version }} --prefer-dist --no-interaction
+
+      - name: Execute tests
+        run: vendor/bin/phpunit

--- a/README.md
+++ b/README.md
@@ -9,13 +9,14 @@ Sqlout is compatible with Laravel 5.8+ to 8.x and Scout 7.1+ / 8.x.
 
 ## Version Compatibility
 
- Laravel  | Scout     | Sqlout
-:---------|:----------|:----------
- 5.8      | 7.1 / 7.2 | 1.x / 2.0
- 6.x      | 7.1 / 7.2 | 1.x / 2.0
- 6.x      | 8.x       | 2.0
- 7.x      | 8.x       | 2.0
- 8.x      | 8.x       | 3.x
+ Laravel   | Scout     | Sqlout
+:----------|:----------|:----------
+ 5.8       | 7.1 / 7.2 | 1.x / 2.0
+ 6.x       | 7.1 / 7.2 | 1.x / 2.0
+ 6.x       | 8.x       | 2.0
+ 7.x       | 8.x       | 2.0
+ 8.x       | 8.x       | 3.x
+ 8.x / 9.x | 9.x       | 4.x
 
 ## Setup
 
@@ -216,11 +217,12 @@ return [
             'est',
             'les',
         ],
-        'stemmer' => Wamania\Snowball\French::class,
+        'stemmer' => Wamania\Snowball\StemmerFactory::create('french'),
     ],
 ];
 ```
 
-In the example, the stemmer comes from the package
-[`wamania/php-stemmer`](https://github.com/wamania/php-stemmer), but any class
-with a `stem` method, or anything callable such as a closure, will do.
+In the example, the stemmer comes from the package [`wamania/php-stemmer`],
+but any class with a `stem` method, or anything callable such as a closure, will do.
+
+[`wamania/php-stemmer`]: https://github.com/wamania/php-stemmer

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     "require-dev": {
         "squizlabs/php_codesniffer": "^2.8",
         "wamania/php-stemmer": "^3.0",
-        "orchestra/testbench": "^6.0|^7.0",
+        "orchestra/testbench": "^6.23|^7.0",
         "laravel/legacy-factories": "^1.1"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -7,15 +7,15 @@
     "license": "MIT",
     "type": "library",
     "require": {
-        "php": ">=7.0",
-        "illuminate/database": "^8.0",
-        "illuminate/support": "^8.0",
-        "laravel/scout": "^8.0"
+        "php": "^7.3|^8.0",
+        "illuminate/database": "^8.0|^9.0",
+        "illuminate/support": "^8.0|^9.0",
+        "laravel/scout": "^9.0"
     },
     "require-dev": {
         "squizlabs/php_codesniffer": "^2.8",
         "wamania/php-stemmer": "^1.2",
-        "orchestra/testbench": "^6.0",
+        "orchestra/testbench": "^6.0|^7.0",
         "laravel/legacy-factories": "^1.1"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     },
     "require-dev": {
         "squizlabs/php_codesniffer": "^2.8",
-        "wamania/php-stemmer": "^1.2",
+        "wamania/php-stemmer": "^3.0",
         "orchestra/testbench": "^6.0|^7.0",
         "laravel/legacy-factories": "^1.1"
     },

--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
     "extra": {
         "branch-alias": {
             "dev-master": "3.0.x-dev"
-        }
+        },
         "laravel": {
             "providers": [
                 "Baril\\Sqlout\\SqloutServiceProvider"

--- a/composer.json
+++ b/composer.json
@@ -36,6 +36,9 @@
         "baril/smoothie": "Some fruity additions to Laravel's Eloquent."
     },
     "extra": {
+        "branch-alias": {
+            "dev-master": "3.0.x-dev"
+        }
         "laravel": {
             "providers": [
                 "Baril\\Sqlout\\SqloutServiceProvider"

--- a/config/scout.php
+++ b/config/scout.php
@@ -94,7 +94,7 @@ return [
 //            'est',
 //            'les',
 //        ],
-//        'stemmer' => Wamania\Snowball\French::class, // from package wamania/php-stemmer
+//        'stemmer' => Wamania\Snowball\StemmerFactory::create('french'), // from package wamania/php-stemmer
     ],
 
 ];

--- a/src/Engine.php
+++ b/src/Engine.php
@@ -53,7 +53,11 @@ class Engine extends ScoutEngine
             if (is_string($stemmer) && class_exists($stemmer) && method_exists($stemmer, 'stem')) {
                 $stemmer = [new $stemmer, 'stem'];
             }
-            if (is_callable($stemmer)) {
+            if (is_object($stemmer) && method_exists($stemmer, 'stem')) {
+                foreach ($words as $k => $word) {
+                    $words[$k] = $stemmer->stem($word);
+                }
+            } elseif (is_callable($stemmer)) {
                 foreach ($words as $k => $word) {
                     $words[$k] = call_user_func($stemmer, $word);
                 }

--- a/src/Engine.php
+++ b/src/Engine.php
@@ -6,6 +6,7 @@ use Closure;
 use Exception;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Support\Collection;
+use Illuminate\Support\LazyCollection;
 use Laravel\Scout\Engines\Engine as ScoutEngine;
 use Laravel\Scout\Builder;
 
@@ -251,6 +252,23 @@ class Engine extends ScoutEngine
     }
 
     /**
+     * Map the given results to instances of the given model via a lazy collection.
+     *
+     * @param  \Laravel\Scout\Builder  $builder
+     * @param  mixed  $results
+     * @param  \Illuminate\Database\Eloquent\Model  $model
+     * @return \Illuminate\Support\LazyCollection
+     */
+    public function lazyMap(Builder $builder, $results, $model)
+    {
+        $models = $results['hits']->map(function ($hit) {
+            $hit->record->_score = $hit->_score;
+            return $hit->record;
+        })->all();
+        return new LazyCollection($models);
+    }
+
+    /**
      * Get the total count from a raw result returned by the engine.
      *
      * @param  mixed  $results
@@ -270,5 +288,28 @@ class Engine extends ScoutEngine
     public function flush($model)
     {
         $this->newSearchQuery($model)->where('record_type', $model->getMorphClass())->delete();
+    }
+
+    /**
+     * Create a search index.
+     *
+     * @param  string  $name
+     * @param  array  $options
+     * @return mixed
+     */
+    public function createIndex($name, array $options = [])
+    {
+        //
+    }
+
+    /**
+     * Delete a search index.
+     *
+     * @param  string  $name
+     * @return mixed
+     */
+    public function deleteIndex($name)
+    {
+        //
     }
 }

--- a/tests/SearchTest.php
+++ b/tests/SearchTest.php
@@ -8,7 +8,7 @@ use Baril\Sqlout\SearchIndex;
 use Baril\Sqlout\Tests\Models\Comment;
 use Baril\Sqlout\Tests\Models\Post;
 use Illuminate\Database\Eloquent\Relations\Relation;
-use Wamania\Snowball\French as FrenchStemmer;
+use Wamania\Snowball\StemmerFactory;
 
 class SearchTest extends TestCase
 {
@@ -200,7 +200,7 @@ class SearchTest extends TestCase
 
         $this->assertEquals(0, Post::search('chanter')->count());
 
-        app('config')->set('scout.sqlout.stemmer', FrenchStemmer::class);
+        app('config')->set('scout.sqlout.stemmer', StemmerFactory::create('french'));
         $posts->searchable();
 
         $this->assertEquals(1, Post::search('chanter')->count());


### PR DESCRIPTION
# Adds
- GitHub Actions for running tests against supported versions.
- Support for PHP 8.
- Support for Laravel 9.

# Changes
- Minimum supported PHP version to ^7.3.
- Laravel Scout version to ^9.0.
- Supported wamania/php-stemmer version to v3 and allows passing in the stemmer object directly.